### PR TITLE
Fix UniFi switch host option handling

### DIFF
--- a/switch.py
+++ b/switch.py
@@ -4,12 +4,12 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import CONF_HOST, DOMAIN
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
     shared = hass.data[DOMAIN][entry.entry_id]
-    host = entry.data.get("host")
+    host = entry.options.get(CONF_HOST, entry.data.get(CONF_HOST)) or "unknown"
     async_add_entities([UniFiAutoSpeedtestSwitch(shared, host)])
 
 


### PR DESCRIPTION
## Summary
- ensure the auto speedtest switch uses updated host values from options

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d14e83347c832dbd234676596edc78