### PR TITLE
Use async_create_clientsession for HA 2025.10 compatibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Optional
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, CALLBACK_TYPE
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -41,7 +41,7 @@ class UnifiWanClient:
         self.api_key = (api_key or "").strip()
         self.site = site or DEFAULT_SITE
         self.verify_ssl = bool(verify_ssl)
-        self._session = async_get_clientsession(hass, self.verify_ssl)
+        self._session = async_create_clientsession(hass, verify_ssl=self.verify_ssl)
 
     def _url(self, path: str) -> str:
         return f"https://{self.host}/proxy/network/api/s/{self.site}/{path}"

--- a/config_flow.py
+++ b/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import (
     DOMAIN,
@@ -33,7 +33,7 @@ async def _async_validate(hass: HomeAssistant, host: str, api_key: str, site: st
     host = (host or "").strip().rstrip("/")
     api_key = (api_key or "").strip()
     site = (site or DEFAULT_SITE).strip()
-    session = async_get_clientsession(hass, verify_ssl)
+    session = async_create_clientsession(hass, verify_ssl=verify_ssl)
     url = f"https://{host}/proxy/network/api/s/{site}/stat/device"
     headers = {"X-API-Key": api_key}
     async with session.get(url, headers=headers) as resp:

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_wan",
   "name": "UniFi WAN",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "documentation": "https://github.com/unifi-wan",
   "issue_tracker": "https://github.com/unifi-wan/issues",
   "codeowners": ["@holdestmade"],
@@ -9,5 +9,6 @@
   "iot_class": "local_polling",
   "loggers": ["custom_components.unifi_wan"],
   "requirements": [],
-  "integration_type": "hub"
+  "integration_type": "hub",
+  "homeassistant": "2025.10.0"
 }


### PR DESCRIPTION
## Summary
- replace deprecated async_get_clientsession usage with async_create_clientsession to align with Home Assistant 2025.10
- bump the integration version and declare the minimum supported Home Assistant release

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e515988474832da396a9dc1fe7a921