### PR TITLE
Fix Problem Caused by Late Binding

### DIFF
--- a/custom_components/unifi_wan/binary_sensor.py
+++ b/custom_components/unifi_wan/binary_sensor.py
@@ -55,14 +55,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             key=f"wan{wan_number}_internet",
             name=f"UniFi WAN{wan_number} Internet",
             device_class=BinarySensorDeviceClass.CONNECTIVITY,
-            value_fn=lambda d: bool(d.wan[wan_number].get("ip")),
+            value_fn=lambda d, wn=wan_number: bool(d.wan[wn].get("ip")),
         )
         entities.append(UniFiGenericBinary(device, host, site, devname, meta, internet))
         link = UniFiBinaryEntityDescription(
             key=f"wan{wan_number}_link",
             name=f"UniFi WAN{wan_number} Link",
             device_class=BinarySensorDeviceClass.CONNECTIVITY,
-            value_fn=lambda d: bool(d.wan[wan_number].get("up")),
+            value_fn=lambda d, wn=wan_number: bool(d.wan[wn].get("up")),
         )
         entities.append(UniFiGenericBinary(device, host, site, devname, meta, link))
 

--- a/custom_components/unifi_wan/sensor.py
+++ b/custom_components/unifi_wan/sensor.py
@@ -190,7 +190,7 @@ async def async_setup_entry(
             key=f"wan{wan_number}_ipv4",
             name=f"UniFi WAN{wan_number} IPv4",
             icon="mdi:ip",
-            value_fn=lambda d: d.wan[wan_number].get("ip") or "unknown",
+            value_fn=lambda d, wn=wan_number: d.wan[wn].get("ip") or "unknown",
         )
         coord: DataUpdateCoordinator = (
             rates_coord if "mbps" in ipv4.key else device_coord
@@ -209,7 +209,7 @@ async def async_setup_entry(
             key=f"wan{wan_number}_ipv6",
             name=f"UniFi WAN{wan_number} IPv6",
             icon="mdi:ip-network-outline",
-            value_fn=lambda d: d.wan[wan_number].get("ip6") or "unknown",
+            value_fn=lambda d, wn=wan_number: d.wan[wn].get("ip6") or "unknown",
         )
         coord: DataUpdateCoordinator = (
             rates_coord if "mbps" in ipv6.key else device_coord


### PR DESCRIPTION
This PR fixes the issue #12 where the information for each WAN interface is always the last one for some entries. 

Fixes #12