### PR TITLE
fix: resolve bugs and optimise component structure

### DIFF
--- a/custom_components/unifi_wan/__init__.py
+++ b/custom_components/unifi_wan/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from datetime import timedelta
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall, CALLBACK_TYPE
@@ -12,12 +12,14 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.const import CONF_HOST, CONF_API_KEY, CONF_VERIFY_SSL
 
 from .const import (
     DOMAIN,
     PLATFORMS,
+    CONF_HOST,
+    CONF_API_KEY,
     CONF_SITE,
+    CONF_VERIFY_SSL,
     CONF_SCAN_INTERVAL,
     CONF_RATE_INTERVAL,
     CONF_AUTO_SPEEDTEST,
@@ -241,8 +243,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raw = await client.get_devices()
         return _extract_wan_data(raw)
 
-    wan_numbers = (await _update_devices()).wan.keys()
-
     device_coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
@@ -259,7 +259,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         dev_meta["model"] = gw.get("model") or gw.get("type") or "UDM/UGW"
         dev_meta["mac"] = gw.get("mac")
 
-    rates_coordinator: Optional[DataUpdateCoordinator] = None
+    wan_numbers = device_coordinator.data.wan.keys()
+
+    rates_coordinator: DataUpdateCoordinator | None = None
     if dev_meta["mac"] and rate_seconds > 0:
         mac = dev_meta["mac"]
         async def _update_rates():
@@ -277,7 +279,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     entry_signal = f"{SIGNAL_SPEEDTEST_RUNNING}_{entry.entry_id}"
     speedtest_running: bool = False
-    unsub_auto: Optional[CALLBACK_TYPE] = None
+    unsub_auto: CALLBACK_TYPE | None = None
 
     def _dispatch_running():
         async_dispatcher_send(hass, entry_signal)
@@ -306,7 +308,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await set_speedtest_running(True)
         try:
             await client.run_speedtest(mac_local, wan_number)
-            await asyncio.sleep(15) 
+            # Brief pause to allow the gateway to begin the test before we refresh
+            await asyncio.sleep(15)
         except Exception as e:
             _LOGGER.error("Speedtest trigger failed: %s", e)
         finally:
@@ -340,7 +343,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "site": site,
         "dev_meta": dev_meta,
         "auto_enabled": auto_enabled,
-        "auto_unsub": unsub_auto,
         "manage_auto": _schedule_auto,
         "run_speedtest_now": _run_speedtest_now,
         "speedtest_running_signal": entry_signal,

--- a/custom_components/unifi_wan/binary_sensor.py
+++ b/custom_components/unifi_wan/binary_sensor.py
@@ -14,8 +14,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
 
-from .const import DOMAIN, CONF_HOST, CONF_SITE
-from .__init__ import UniFiWanData
+from .const import DOMAIN
+from . import UniFiWanData
 
 @dataclass
 class UniFiBinaryEntityDescription(BinarySensorEntityDescription):
@@ -32,8 +32,8 @@ BINARY_SENSORS: tuple[UniFiBinaryEntityDescription, ...] = (
         key="active_wan_up",
         name="UniFi Active WAN Up",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
-        value_fn=lambda d: any(d.wan_alive.values()) if d.wan_alive else bool(d.uplink.get("up")),
-    )
+        value_fn=lambda d: bool(d.uplink.get("up")),
+    ),
 )
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
@@ -55,14 +55,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             key=f"wan{wan_number}_internet",
             name=f"UniFi WAN{wan_number} Internet",
             device_class=BinarySensorDeviceClass.CONNECTIVITY,
-            value_fn=lambda d, wn=wan_number: d.wan_alive.get(wn, bool(d.wan[wn].get("ip"))),
+            value_fn=lambda d, wn=wan_number: d.wan_alive.get(wn, bool(d.wan.get(wn, {}).get("ip"))),
         )
         entities.append(UniFiGenericBinary(device, host, site, devname, meta, internet))
         link = UniFiBinaryEntityDescription(
             key=f"wan{wan_number}_link",
             name=f"UniFi WAN{wan_number} Link",
             device_class=BinarySensorDeviceClass.CONNECTIVITY,
-            value_fn=lambda d, wn=wan_number: bool(d.wan[wn].get("up")),
+            value_fn=lambda d, wn=wan_number: bool(d.wan.get(wn, {}).get("up")),
         )
         entities.append(UniFiGenericBinary(device, host, site, devname, meta, link))
 

--- a/custom_components/unifi_wan/sensor.py
+++ b/custom_components/unifi_wan/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.config_entries import ConfigEntry
 
 from .const import DOMAIN
-from .__init__ import UniFiWanData
+from . import UniFiWanData
 
 
 DATA_RATE_UNIT_MEGABITS_PER_SECOND: Final = "Mbit/s"
@@ -220,39 +220,19 @@ async def async_setup_entry(
             key=f"wan{wan_number}_ipv4",
             name=f"UniFi WAN{wan_number} IPv4",
             icon="mdi:ip",
-            value_fn=lambda d, wn=wan_number: d.wan[wn].get("ip") or "unknown",
-        )
-        coord: DataUpdateCoordinator = (
-            rates_coord if ipv4.use_rate_coordinator else device_coord
+            value_fn=lambda d, wn=wan_number: d.wan.get(wn, {}).get("ip") or "unknown",
         )
         entities.append(
-            UniFiGenericSensor(
-                coord,
-                host,
-                site,
-                devname,
-                meta,
-                ipv4,
-            )
+            UniFiGenericSensor(device_coord, host, site, devname, meta, ipv4)
         )
         ipv6 = UniFiSensorDescription(
             key=f"wan{wan_number}_ipv6",
             name=f"UniFi WAN{wan_number} IPv6",
             icon="mdi:ip-network-outline",
-            value_fn=lambda d, wn=wan_number: d.wan[wn].get("ip6") or "unknown",
-        )
-        coord: DataUpdateCoordinator = (
-            rates_coord if ipv6.use_rate_coordinator else device_coord
+            value_fn=lambda d, wn=wan_number: d.wan.get(wn, {}).get("ip6") or "unknown",
         )
         entities.append(
-            UniFiGenericSensor(
-                coord,
-                host,
-                site,
-                devname,
-                meta,
-                ipv6,
-            )
+            UniFiGenericSensor(device_coord, host, site, devname, meta, ipv6)
         )
 
     async_add_entities(entities)

--- a/custom_components/unifi_wan/switch.py
+++ b/custom_components/unifi_wan/switch.py
@@ -8,7 +8,7 @@ from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import DOMAIN, CONF_AUTO_SPEEDTEST
+from .const import DOMAIN
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
@@ -17,7 +17,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     host = shared["host"]
     site = shared["site"]
     devname = f"UniFi WAN ({host} / {site})"
-    async_add_entities([UniFiAutoSpeedtestSwitch(shared, entry, host, site, devname, meta)])
+    async_add_entities([UniFiAutoSpeedtestSwitch(shared, host, site, devname, meta)])
 
 
 class UniFiAutoSpeedtestSwitch(SwitchEntity, RestoreEntity):
@@ -28,14 +28,12 @@ class UniFiAutoSpeedtestSwitch(SwitchEntity, RestoreEntity):
     def __init__(
         self,
         shared: dict[str, Any],
-        entry: ConfigEntry,
         host: str,
         site: str,
         devname: str,
         meta: dict[str, Any],
     ):
         self._shared = shared
-        self._entry = entry
         self._host = host
         self._site = site
         self._devname = devname
@@ -69,12 +67,8 @@ class UniFiAutoSpeedtestSwitch(SwitchEntity, RestoreEntity):
         self._shared["manage_auto"](True)
         self._shared["auto_enabled"] = True
         self.async_write_ha_state()
-        new_options = {**self._entry.options, CONF_AUTO_SPEEDTEST: True}
-        self.hass.config_entries.async_update_entry(self._entry, options=new_options)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         self._shared["manage_auto"](False)
         self._shared["auto_enabled"] = False
         self.async_write_ha_state()
-        new_options = {**self._entry.options, CONF_AUTO_SPEEDTEST: False}
-        self.hass.config_entries.async_update_entry(self._entry, options=new_options)


### PR DESCRIPTION
- __init__.py: remove duplicate API call during setup (wan_numbers now
  derived from coordinator data after first refresh, not a redundant
  _update_devices() call); import CONF_HOST/API_KEY/VERIFY_SSL from
  local const consistently; replace Optional[X] with X | None; remove
  vestigial auto_unsub key from shared dict; add comment on sleep(15)
- binary_sensor.py: fix active_wan_up having identical value_fn to
  wan_internet (now checks uplink.get("up") for the active WAN only);
  guard per-WAN lambdas with .get(wn, {}) to avoid KeyError if a WAN
  disappears from API data; remove unused CONF_HOST/CONF_SITE imports;
  switch to idiomatic `from . import UniFiWanData`
- sensor.py: guard per-WAN lambdas with .get(wn, {}) to avoid KeyError;
  simplify per-WAN entity loop (remove redundant coord re-assignments
  since use_rate_coordinator is always False for these sensors); switch
  to idiomatic `from . import UniFiWanData`
- switch.py: remove async_update_entry calls that incorrectly triggered
  the update listener and caused a full integration reload on every
  toggle; RestoreEntity already persists state across restarts

https://claude.ai/code/session_01D8xEDnm5jcwcQaA2MHyBFy