### PR TITLE
Add debug logging and sensor attributes for WAN diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+__pycache__/
+*.pyc

--- a/custom_components/unifi_wan/__init__.py
+++ b/custom_components/unifi_wan/__init__.py
@@ -106,6 +106,43 @@ class UnifiWanClient:
         return await self.post_json("cmd/devmgr", payload)
 
 
+def _log_raw_payload(payload: dict[str, Any] | None, devices: list[dict]) -> None:
+    """Emit a debug log that surfaces the gateway fields relevant to the
+    IPv6 / speedtest_interface sensors so users can see what the controller
+    is actually returning. Enable with:
+        logger:
+          default: warning
+          logs:
+            custom_components.unifi_wan: debug
+    """
+    if not _LOGGER.isEnabledFor(logging.DEBUG):
+        return
+    gw = None
+    for t in GATEWAY_DEVICES:
+        for d in devices:
+            if isinstance(d, dict) and d.get("type") == t:
+                gw = d
+                break
+        if gw:
+            break
+    if not gw:
+        _LOGGER.debug("UniFi raw payload: no gateway device found in %d devices", len(devices))
+        return
+    uplink = gw.get("uplink") or {}
+    wan_keys = [k for k in gw.keys() if k == "wan" or (k.startswith("wan") and k[3:].isdigit())]
+    wan_dump = {k: gw.get(k) for k in wan_keys}
+    _LOGGER.debug(
+        "UniFi raw gateway debug: uplink_keys=%s uplink.ip=%s uplink.ip6=%s "
+        "uplink.speedtest_interface=%s wan_blocks=%s last_wan_interfaces=%s",
+        sorted(uplink.keys()),
+        uplink.get("ip"),
+        uplink.get("ip6"),
+        uplink.get("speedtest_interface"),
+        wan_dump,
+        gw.get("last_wan_interfaces"),
+    )
+
+
 def _get_ip6_from(data: dict[str, Any]) -> str | None:
     """Extract an IPv6 address from a data dict, trying multiple field names and formats."""
     for key in ("ip6", "ip6_address", "ipv6_address"):
@@ -130,6 +167,8 @@ def _extract_wan_data(payload: dict[str, Any] | None) -> UniFiWanData:
     devices = []
     if isinstance(payload, dict):
         devices = payload.get("data", []) or []
+
+    _log_raw_payload(payload, devices)
     
     gateway = None
     for t in GATEWAY_DEVICES:

--- a/custom_components/unifi_wan/sensor.py
+++ b/custom_components/unifi_wan/sensor.py
@@ -31,6 +31,7 @@ class UniFiSensorDescription(SensorEntityDescription):
     """Description for UniFi Sensors."""
 
     value_fn: Callable[[UniFiWanData], Any] = lambda x: None
+    attributes_fn: Callable[[UniFiWanData], dict[str, Any] | None] | None = None
     use_rate_coordinator: bool = False
 
 
@@ -89,6 +90,14 @@ SENSORS: Final[tuple[UniFiSensorDescription, ...]] = (
         name="UniFi WAN IPv6",
         icon="mdi:ip-network-outline",
         value_fn=lambda d: d.uplink.get("ip6") or "unknown",
+        attributes_fn=lambda d: {
+            "uplink_keys": sorted((d.uplink or {}).keys()),
+            "uplink_ip": d.uplink.get("ip"),
+            "uplink_ip6": d.uplink.get("ip6"),
+            "uplink_ip6_address": d.uplink.get("ip6_address"),
+            "uplink_ipv6_addresses": d.uplink.get("ipv6_addresses"),
+            "uplink_ip6_addresses": d.uplink.get("ip6_addresses"),
+        },
     ),
     UniFiSensorDescription(
         key="wan_down_mbps",
@@ -167,6 +176,14 @@ SENSORS: Final[tuple[UniFiSensorDescription, ...]] = (
         name="UniFi Speedtest WAN Interface",
         icon="mdi:wan",
         value_fn=lambda d: d.uplink.get("speedtest_interface") or "unknown",
+        attributes_fn=lambda d: {
+            "speedtest_interface": d.uplink.get("speedtest_interface"),
+            "speedtest_lastrun": d.uplink.get("speedtest_lastrun"),
+            "speedtest_status": d.uplink.get("speedtest_status"),
+            "xput_down": d.uplink.get("xput_down"),
+            "xput_up": d.uplink.get("xput_up"),
+            "uplink_keys": sorted((d.uplink or {}).keys()),
+        },
     ),
     UniFiSensorDescription(
         key="active_wan_id",
@@ -230,6 +247,14 @@ async def async_setup_entry(
             name=f"UniFi WAN{wan_number} IPv6",
             icon="mdi:ip-network-outline",
             value_fn=lambda d, wn=wan_number: d.wan.get(wn, {}).get("ip6") or "unknown",
+            attributes_fn=lambda d, wn=wan_number: {
+                "wan_keys": sorted((d.wan.get(wn) or {}).keys()),
+                "ip": (d.wan.get(wn) or {}).get("ip"),
+                "ip6": (d.wan.get(wn) or {}).get("ip6"),
+                "ip6_address": (d.wan.get(wn) or {}).get("ip6_address"),
+                "ipv6_addresses": (d.wan.get(wn) or {}).get("ipv6_addresses"),
+                "ip6_addresses": (d.wan.get(wn) or {}).get("ip6_addresses"),
+            },
         )
         entities.append(
             UniFiGenericSensor(device_coord, host, site, devname, meta, ipv6)
@@ -275,3 +300,13 @@ class UniFiGenericSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> Any:
         return self.entity_description.value_fn(self.coordinator.data)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        fn = self.entity_description.attributes_fn
+        if fn is None:
+            return None
+        try:
+            return fn(self.coordinator.data)
+        except Exception:
+            return None


### PR DESCRIPTION
## Summary
This PR enhances debugging capabilities and provides additional diagnostic information for WAN sensors by adding debug logging and extra state attributes to sensors.

## Key Changes
- **Debug Logging**: Added `_log_raw_payload()` function that emits detailed debug logs showing gateway fields relevant to IPv6 and speedtest_interface sensors. This helps users understand what the UniFi controller is actually returning when debugging connectivity issues.
- **Sensor Attributes**: Extended sensor descriptions with an `attributes_fn` field to expose additional diagnostic data as extra state attributes:
  - IPv6 sensor now exposes all uplink keys and related IP address fields
  - Speedtest WAN Interface sensor now exposes speedtest status, last run time, and throughput metrics
  - Per-WAN IPv6 sensors now expose WAN-specific IP address fields
- **Error Handling**: Added try-except block in `extra_state_attributes` property to gracefully handle any errors when computing attributes
- **Gitignore**: Updated to exclude Python cache files (`__pycache__/` and `*.pyc`)

## Implementation Details
- Debug logging is only emitted when the logger is explicitly set to DEBUG level for the component, avoiding performance overhead in normal operation
- The `_log_raw_payload()` function searches through devices to find the gateway and logs relevant uplink and WAN configuration data
- Attributes are computed on-demand via lambda functions passed to sensor descriptions, allowing flexible access to coordinator data
- The attributes provide visibility into fields that may vary across different UniFi controller versions, helping diagnose configuration issues

https://claude.ai/code/session_018qG8gzDcXKKZcjnm6XmaA7