### PR TITLE
fix: recognise wan.ipv6 list and derive speedtest interface fallback

### DIFF
--- a/custom_components/unifi_wan/__init__.py
+++ b/custom_components/unifi_wan/__init__.py
@@ -149,7 +149,7 @@ def _get_ip6_from(data: dict[str, Any]) -> str | None:
         val = data.get(key)
         if val and isinstance(val, str):
             return val
-    for key in ("ip6_addresses", "ipv6_addresses"):
+    for key in ("ipv6", "ip6_addresses", "ipv6_addresses"):
         val = data.get(key)
         if val and isinstance(val, list):
             for entry in val:

--- a/custom_components/unifi_wan/sensor.py
+++ b/custom_components/unifi_wan/sensor.py
@@ -78,6 +78,19 @@ def _wan_name(d: UniFiWanData) -> str:
     return c or n or "Unknown"
 
 
+def _speedtest_interface(d: UniFiWanData) -> str:
+    """Return the controller-reported speedtest interface, or fall back
+    to the active WAN ID. Newer/older controller versions don't always
+    populate uplink.speedtest_interface, but the speedtest always runs
+    against the active uplink so the active WAN ID is a safe fallback.
+    """
+    iface = d.uplink.get("speedtest_interface")
+    if iface:
+        return iface
+    active = _wan_id(d)
+    return active if active != "Unknown" else "unknown"
+
+
 SENSORS: Final[tuple[UniFiSensorDescription, ...]] = (
     UniFiSensorDescription(
         key="wan_ipv4",
@@ -175,14 +188,14 @@ SENSORS: Final[tuple[UniFiSensorDescription, ...]] = (
         key="speedtest_interface",
         name="UniFi Speedtest WAN Interface",
         icon="mdi:wan",
-        value_fn=lambda d: d.uplink.get("speedtest_interface") or "unknown",
+        value_fn=_speedtest_interface,
         attributes_fn=lambda d: {
-            "speedtest_interface": d.uplink.get("speedtest_interface"),
+            "raw_speedtest_interface": d.uplink.get("speedtest_interface"),
+            "derived_from_active_wan": not bool(d.uplink.get("speedtest_interface")),
             "speedtest_lastrun": d.uplink.get("speedtest_lastrun"),
             "speedtest_status": d.uplink.get("speedtest_status"),
             "xput_down": d.uplink.get("xput_down"),
             "xput_up": d.uplink.get("xput_up"),
-            "uplink_keys": sorted((d.uplink or {}).keys()),
         },
     ),
     UniFiSensorDescription(


### PR DESCRIPTION
The controller exposes IPv6 under a singular 'ipv6' list key on per-WAN blocks, which the existing fallback didn't check. Older/newer controller versions also omit uplink.speedtest_interface entirely, so derive it from the active WAN when missing since the speedtest always runs against the active uplink.

https://claude.ai/code/session_018qG8gzDcXKKZcjnm6XmaA7