### PR TITLE
Fix stale WAN internet status by checking physical link state

### DIFF
--- a/custom_components/unifi_wan/binary_sensor.py
+++ b/custom_components/unifi_wan/binary_sensor.py
@@ -51,11 +51,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         entities.append(UniFiGenericBinary(device, host, site, devname, meta, desc))
 
     for wan_number in wan_numbers:
+        # The controller's last_wan_interfaces "alive" flag can stay stale for a
+        # WAN whose cable is unplugged, so a WAN with no physical link is never
+        # treated as having internet regardless of the reported alive state.
         internet = UniFiBinaryEntityDescription(
             key=f"wan{wan_number}_internet",
             name=f"UniFi WAN{wan_number} Internet",
             device_class=BinarySensorDeviceClass.CONNECTIVITY,
-            value_fn=lambda d, wn=wan_number: d.wan_alive.get(wn, bool(d.wan.get(wn, {}).get("ip"))),
+            value_fn=lambda d, wn=wan_number: bool(d.wan.get(wn, {}).get("up")) and d.wan_alive.get(wn, bool(d.wan.get(wn, {}).get("ip"))),
         )
         entities.append(UniFiGenericBinary(device, host, site, devname, meta, internet))
         link = UniFiBinaryEntityDescription(


### PR DESCRIPTION
## Summary
Fixed an issue where the UniFi WAN internet connectivity status could report as "alive" even when the physical cable is unplugged. The controller's `last_wan_interfaces` "alive" flag can become stale for disconnected WANs, so we now require the physical link to be up before considering the WAN as having internet.

## Key Changes
- Updated the `wan{wan_number}_internet` binary sensor's `value_fn` to check the physical link state (`up` flag) in addition to the alive status
- The sensor now only reports internet connectivity when both:
  1. The physical WAN link is up (`d.wan.get(wn, {}).get("up")`)
  2. AND the controller reports the WAN as alive or has an IP address
- Added clarifying comments explaining why the physical link check is necessary

## Implementation Details
The change ensures that a WAN interface with no physical link will never be treated as having internet connectivity, regardless of what the controller's stale "alive" flag reports. This prevents false positives when cables are unplugged but the controller hasn't updated its internal state yet.

https://claude.ai/code/session_01Nj3UXa4K2wa518syJF3a9E