### PR TITLE
Add per-WAN speedtest result tracking and improve WAN detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,18 +62,24 @@ Speedtest values are taken from the gateway’s `uplink` section after a speedte
 - **UniFi Speedtest Last Run**  
   - Timestamp of the last speedtest  
 
+**Per-WAN speedtest**
+
+The controller only stores the *latest* speedtest result, overwriting it on every run regardless of interface. The integration therefore attributes each completed run to a WAN interface — using the controller-reported speedtest interface where available, otherwise the interface the test was requested on, otherwise the active WAN — and keeps the last result per WAN. Values survive Home Assistant restarts and update only when a speedtest actually runs on that WAN.
+
+- **UniFi WAN\* Speedtest Download** (**Mbit/s**)  
+- **UniFi WAN\* Speedtest Upload** (**Mbit/s**)  
+- **UniFi WAN\* Speedtest Ping** (**ms**)  
+- **UniFi WAN\* Speedtest Last Run** (timestamp)
+
 **WAN identification**
 
-- **UniFi Active WAN Name**  
-  - Human-friendly description of the currently active WAN  
 - **UniFi Active WAN ID**  
   - Logical ID of the active WAN (e.g. `WAN1`), or `Unknown`  
-  - Heuristically derived from:
-    - IP matches
-    - Interface name matches
-    - WAN section `up` flags
-    - Legacy single-WAN `wan` section  
-  - Attributes include the chosen section IP/interface and the match reason for debugging.
+  - Derived by matching the uplink IP against each WAN section, then the uplink port name against each WAN section's interface name, then falling back to the only WAN that is up  
+  - Attributes include the resolved WAN, the match reason and the per-WAN IPs/interface names for debugging
+- **UniFi Active WAN Name**  
+  - Human-friendly description of the currently active WAN  
+  - Always derived from the same WAN section as **UniFi Active WAN ID**, so the two sensors can never point at different interfaces (in load-balanced dual-WAN setups the controller's uplink object can mix fields from both interfaces)
 
 ---
 
@@ -152,7 +158,8 @@ All options are available via the integration’s **Options** UI and can be chan
 - **Run speedtest automatically** (on/off, default **on**)  
   - Enable/disable automatic speedtests entirely.
 - **Auto speedtest interval (minutes)** (default **60**)  
-  - How often to trigger an automatic speedtest when enabled.
+  - How often to trigger an automatic speedtest when enabled.  
+  - With more than one WAN interface, each run cycles to the next WAN that currently has link, so every WAN accumulates its own per-WAN speedtest results over time. With a single WAN the plain speedtest command is used.
 
 ---
 

--- a/custom_components/unifi_wan/__init__.py
+++ b/custom_components/unifi_wan/__init__.py
@@ -40,6 +40,7 @@ from .const import (
     LEGACY_CONF_DEVICE_INTERVAL,
     SIGNAL_SPEEDTEST_RUNNING,
     SIGNAL_AUTO_SPEEDTEST_CHANGED,
+    SIGNAL_SPEEDTEST_RESULT,
     GATEWAY_DEVICES,
     MAX_WAN_INTERFACES,
     SERVICE_RUN_SPEEDTEST,
@@ -93,6 +94,8 @@ class UniFiWanRuntimeData:
     set_speedtest_running: Callable[[bool], Awaitable[None]]
     wan_numbers: list[int]
     reload_signature: dict[str, Any]
+    speedtest_results: dict[int, dict[str, Any]]
+    speedtest_result_signal: str
 
 
 class UnifiWanClient:
@@ -328,6 +331,54 @@ def _extract_wan_data(payload: dict[str, Any] | None) -> UniFiWanData:
     )
 
 
+def resolve_active_wan(d: UniFiWanData) -> tuple[int | None, str]:
+    """Resolve which WAN number is the active uplink, and how it was matched.
+
+    This is the single source of truth used by both the Active WAN ID and
+    Active WAN Name sensors, so the two can never point at different
+    interfaces. Match order: the uplink's IP against each WAN section's IP,
+    then the uplink's port name against each WAN section's ifname, and
+    finally the only WAN that is up. In load-balanced dual-WAN setups the
+    controller's uplink object can mix fields from both interfaces, which
+    is why the IP match takes precedence over the port name.
+    """
+    u_ip = d.uplink.get("ip")
+    if u_ip:
+        for wan_number, wan_data in d.wan.items():
+            if u_ip == wan_data.get("ip"):
+                return wan_number, "uplink_ip"
+    u_name = str(d.uplink.get("name") or "").strip().lower()
+    if u_name:
+        for wan_number, wan_data in d.wan.items():
+            if u_name == str(wan_data.get("ifname") or "").strip().lower():
+                return wan_number, "uplink_ifname"
+    up_numbers = [n for n, wan_data in d.wan.items() if wan_data.get("up")]
+    if len(up_numbers) == 1:
+        return up_numbers[0], "only_wan_up"
+    return None, "no_match"
+
+
+def _interface_to_wan_number(iface: Any, wan: dict[int, dict[str, Any]]) -> int | None:
+    """Map a controller-reported speedtest interface to a WAN number.
+
+    Handles the "wan"/"wan2" naming used by the speedtest command as well
+    as physical port names (e.g. "eth8") that some firmware reports.
+    """
+    if not isinstance(iface, str):
+        return None
+    s = iface.strip().lower()
+    if not s:
+        return None
+    if s == "wan":
+        return 1
+    if s.startswith("wan") and s[3:].isdigit():
+        return int(s[3:])
+    for wan_number, wan_data in wan.items():
+        if s == str(wan_data.get("ifname") or "").strip().lower():
+            return wan_number
+    return None
+
+
 async def _async_migrate_registry(
     hass: HomeAssistant, entry: ConfigEntry, host: str, site: str
 ) -> None:
@@ -447,11 +498,66 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     entry_signal = f"{SIGNAL_SPEEDTEST_RUNNING}_{entry.entry_id}"
     auto_changed_signal = f"{SIGNAL_AUTO_SPEEDTEST_CHANGED}_{entry.entry_id}"
+    result_signal = f"{SIGNAL_SPEEDTEST_RESULT}_{entry.entry_id}"
     speedtest_running: bool = False
     unsub_auto: CALLBACK_TYPE | None = None
 
+    # Per-WAN speedtest results latched by _process_speedtest_result. The
+    # controller only stores the latest result (on the uplink object), so the
+    # integration attributes each completed run to a WAN and keeps it here.
+    speedtest_results: dict[int, dict[str, Any]] = {}
+    # WAN number requested for the speedtest currently in flight, if any.
+    pending_speedtest_wan: int | None = None
+    # Seed with the result already on the controller so a stale run isn't
+    # re-attributed after every restart; per-WAN sensors restore their own
+    # previous state instead.
+    last_attributed_run = device_coordinator.data.uplink.get("speedtest_lastrun")
+
     def _dispatch_running():
         async_dispatcher_send(hass, entry_signal)
+
+    @callback
+    def _process_speedtest_result() -> None:
+        """Attribute a freshly completed speedtest to a WAN interface.
+
+        Runs on every device coordinator refresh. Attribution order: the
+        controller-reported speedtest interface, then the WAN the in-flight
+        request targeted, then the resolved active WAN.
+        """
+        nonlocal last_attributed_run
+        data: UniFiWanData | None = device_coordinator.data
+        if not data or not data.uplink:
+            return
+        lastrun = data.uplink.get("speedtest_lastrun")
+        if not lastrun or lastrun == last_attributed_run:
+            return
+        last_attributed_run = lastrun
+        down = data.uplink.get("xput_down")
+        up = data.uplink.get("xput_up")
+        if down is None and up is None:
+            return
+        wan_number = _interface_to_wan_number(
+            data.uplink.get("speedtest_interface"), data.wan
+        )
+        if wan_number is None:
+            wan_number = pending_speedtest_wan
+        if wan_number is None:
+            wan_number, _ = resolve_active_wan(data)
+        if wan_number is None:
+            _LOGGER.debug("Speedtest result could not be attributed to a WAN")
+            return
+        speedtest_results[wan_number] = {
+            "down": down,
+            "up": up,
+            "ping": data.uplink.get("speedtest_ping"),
+            "lastrun": lastrun,
+        }
+        _LOGGER.debug("Attributed speedtest result to WAN%s", wan_number)
+        async_dispatcher_send(hass, result_signal)
+
+    entry.async_on_unload(
+        device_coordinator.async_add_listener(_process_speedtest_result)
+    )
 
     async def set_speedtest_running(is_running: bool) -> None:
         nonlocal speedtest_running
@@ -464,11 +570,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Trigger a speedtest, optionally on a specific WAN interface, and
         wait (with a timeout) for the controller to report a fresh result.
         """
+        nonlocal pending_speedtest_wan
         if speedtest_running:
             _LOGGER.debug("Speedtest already in progress; ignoring trigger")
             return
 
         await set_speedtest_running(True)
+        pending_speedtest_wan = wan_number
         try:
             gw_data = device_coordinator.data
             mac_local = gw_data.gateway.get("mac") if gw_data.gateway else None
@@ -502,12 +610,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except Exception as e:
             _LOGGER.error("Speedtest trigger failed: %s", e)
         finally:
+            pending_speedtest_wan = None
             if rates_coordinator:
                 await rates_coordinator.async_request_refresh()
             await set_speedtest_running(False)
 
+    auto_wan_index = 0
+
     async def _auto_speedtest_callback(_now) -> None:
-        await _run_speedtest_now()
+        """Run the scheduled speedtest, cycling through the WAN interfaces
+        that currently have link so each WAN accumulates its own results.
+        With a single WAN the plain speedtest command is kept for maximum
+        firmware compatibility.
+        """
+        nonlocal auto_wan_index
+        data: UniFiWanData | None = device_coordinator.data
+        candidates = [
+            n for n in wan_numbers if (data.wan.get(n) or {}).get("up")
+        ] if data else []
+        if not candidates:
+            candidates = list(wan_numbers)
+        if len(candidates) > 1:
+            wan_number = candidates[auto_wan_index % len(candidates)]
+            auto_wan_index += 1
+            await _run_speedtest_now(wan_number)
+        else:
+            await _run_speedtest_now()
 
     def _schedule_auto(enabled: bool) -> None:
         nonlocal unsub_auto
@@ -549,6 +677,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         set_speedtest_running=set_speedtest_running,
         wan_numbers=wan_numbers,
         reload_signature=_reload_signature(entry),
+        speedtest_results=speedtest_results,
+        speedtest_result_signal=result_signal,
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/unifi_wan/const.py
+++ b/custom_components/unifi_wan/const.py
@@ -35,6 +35,7 @@ PLATFORMS: Final = [
 
 SIGNAL_SPEEDTEST_RUNNING: Final = f"{DOMAIN}_speedtest_running"
 SIGNAL_AUTO_SPEEDTEST_CHANGED: Final = f"{DOMAIN}_auto_speedtest_changed"
+SIGNAL_SPEEDTEST_RESULT: Final = f"{DOMAIN}_speedtest_result"
 SERVICE_RUN_SPEEDTEST: Final = "run_speedtest"
 ATTR_WAN: Final = "wan"
 

--- a/custom_components/unifi_wan/sensor.py
+++ b/custom_components/unifi_wan/sensor.py
@@ -5,13 +5,15 @@ from dataclasses import dataclass
 from typing import Any, Callable, Final
 
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
     SensorEntityDescription,
 )
 from homeassistant.const import UnitOfTime
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -20,7 +22,7 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.config_entries import ConfigEntry
 
 from .const import DOMAIN
-from . import UniFiWanData, UniFiWanRuntimeData
+from . import UniFiWanData, UniFiWanRuntimeData, resolve_active_wan
 
 
 DATA_RATE_UNIT_MEGABITS_PER_SECOND: Final = "Mbit/s"
@@ -54,28 +56,48 @@ def _ts_date(val: Any) -> datetime | None:
 
 def _wan_id(d: UniFiWanData) -> str:
     """Infer Active WAN ID."""
-    u_ip = d.uplink.get("ip")
-    if u_ip:
-        for wan_number in d.wan.keys():
-            if u_ip == d.wan[wan_number].get("ip"):
-                return f"WAN{wan_number}"
-    for wan_number in d.wan.keys():
-        if d.wan[wan_number].get("up") and all(
-            not other_data.get("up")
-            for other_num, other_data in d.wan.items()
-            if other_num != wan_number
-        ):
-            return f"WAN{wan_number}"
-    return "Unknown"
+    wan_number, _ = resolve_active_wan(d)
+    return f"WAN{wan_number}" if wan_number is not None else "Unknown"
 
 
 def _wan_name(d: UniFiWanData) -> str:
-    """Get Active WAN Name."""
-    c = (d.uplink.get("comment") or "").strip()
-    n = (d.uplink.get("name") or "").strip()
+    """Get Active WAN Name, derived from the same WAN section as the Active
+    WAN ID so the two sensors can never point at different interfaces. The
+    controller's uplink comment/name fields are only trusted when they agree
+    with the resolved WAN section (or when no section resolved at all): in
+    load-balanced dual-WAN setups the uplink object can mix fields from both
+    interfaces, e.g. WAN1's IP alongside WAN2's port name.
+    """
+    wan_number, _ = resolve_active_wan(d)
+    if wan_number is None:
+        c = (d.uplink.get("comment") or "").strip()
+        n = (d.uplink.get("name") or "").strip()
+    else:
+        wan_data = d.wan.get(wan_number) or {}
+        ifname = (wan_data.get("ifname") or "").strip()
+        c = (wan_data.get("comment") or "").strip()
+        n = (wan_data.get("name") or "").strip() or ifname
+        if not c:
+            u_name = (d.uplink.get("name") or "").strip()
+            if u_name and u_name.lower() == ifname.lower():
+                c = (d.uplink.get("comment") or "").strip()
     if c and n and c.lower() != n.lower():
         return f"{c} ({n})"
     return c or n or "Unknown"
+
+
+def _active_wan_attributes(d: UniFiWanData) -> dict[str, Any]:
+    """Debug attributes showing how the active WAN was resolved."""
+    wan_number, reason = resolve_active_wan(d)
+    return {
+        "active_wan": wan_number,
+        "match_reason": reason,
+        "uplink_ip": d.uplink.get("ip"),
+        "uplink_name": d.uplink.get("name"),
+        "uplink_comment": d.uplink.get("comment"),
+        "wan_ips": {f"WAN{n}": (w or {}).get("ip") for n, w in d.wan.items()},
+        "wan_ifnames": {f"WAN{n}": (w or {}).get("ifname") for n, w in d.wan.items()},
+    }
 
 
 def _speedtest_interface(d: UniFiWanData) -> str:
@@ -203,14 +225,72 @@ SENSORS: Final[tuple[UniFiSensorDescription, ...]] = (
         name="UniFi Active WAN ID",
         icon="mdi:numeric",
         value_fn=_wan_id,
+        attributes_fn=_active_wan_attributes,
     ),
     UniFiSensorDescription(
         key="active_wan_name",
         name="UniFi Active WAN Name",
         icon="mdi:wan",
         value_fn=_wan_name,
+        attributes_fn=_active_wan_attributes,
     ),
 )
+
+
+def _wan_speedtest_descriptions(
+    wan_number: int,
+) -> tuple[tuple[SensorEntityDescription, str, Callable[[Any], Any] | None], ...]:
+    """Entity descriptions for one WAN's speedtest sensors, as
+    (description, result field, value transform) tuples.
+    """
+    return (
+        (
+            SensorEntityDescription(
+                key=f"wan{wan_number}_speedtest_down",
+                name=f"UniFi WAN{wan_number} Speedtest Download",
+                icon="mdi:download",
+                device_class=SensorDeviceClass.DATA_RATE,
+                state_class=SensorStateClass.MEASUREMENT,
+                native_unit_of_measurement=DATA_RATE_UNIT_MEGABITS_PER_SECOND,
+            ),
+            "down",
+            None,
+        ),
+        (
+            SensorEntityDescription(
+                key=f"wan{wan_number}_speedtest_up",
+                name=f"UniFi WAN{wan_number} Speedtest Upload",
+                icon="mdi:upload",
+                device_class=SensorDeviceClass.DATA_RATE,
+                state_class=SensorStateClass.MEASUREMENT,
+                native_unit_of_measurement=DATA_RATE_UNIT_MEGABITS_PER_SECOND,
+            ),
+            "up",
+            None,
+        ),
+        (
+            SensorEntityDescription(
+                key=f"wan{wan_number}_speedtest_ping",
+                name=f"UniFi WAN{wan_number} Speedtest Ping",
+                icon="mdi:timer",
+                device_class=SensorDeviceClass.DURATION,
+                state_class=SensorStateClass.MEASUREMENT,
+                native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+            ),
+            "ping",
+            None,
+        ),
+        (
+            SensorEntityDescription(
+                key=f"wan{wan_number}_speedtest_last_run",
+                name=f"UniFi WAN{wan_number} Speedtest Last Run",
+                icon="mdi:clock-outline",
+                device_class=SensorDeviceClass.TIMESTAMP,
+            ),
+            "lastrun",
+            _ts_date,
+        ),
+    )
 
 
 async def async_setup_entry(
@@ -226,7 +306,7 @@ async def async_setup_entry(
     device_info = runtime.device_info
     wan_numbers = runtime.wan_numbers
 
-    entities: list[UniFiGenericSensor] = []
+    entities: list[SensorEntity] = []
 
     for desc in SENSORS:
         coord: DataUpdateCoordinator = (
@@ -257,6 +337,13 @@ async def async_setup_entry(
             },
         )
         entities.append(UniFiGenericSensor(device_coord, entry_id, device_info, ipv6))
+
+        for desc, field, transform in _wan_speedtest_descriptions(wan_number):
+            entities.append(
+                UniFiWanSpeedtestSensor(
+                    runtime, entry_id, device_info, desc, wan_number, field, transform
+                )
+            )
 
     async_add_entities(entities)
 
@@ -289,3 +376,59 @@ class UniFiGenericSensor(CoordinatorEntity, SensorEntity):
             return fn(self.coordinator.data)
         except Exception:
             return None
+
+
+class UniFiWanSpeedtestSensor(RestoreSensor):
+    """Per-WAN speedtest result, latched by the integration whenever a
+    completed speedtest is attributed to this WAN interface.
+
+    The controller only stores the latest result globally (on the gateway's
+    uplink object), overwriting it on every run regardless of interface, so
+    these sensors keep the last value seen for their WAN and restore it
+    across restarts instead of re-reading it from the API.
+    """
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        runtime: UniFiWanRuntimeData,
+        entry_id: str,
+        device_info: dict[str, Any],
+        description: SensorEntityDescription,
+        wan_number: int,
+        field: str,
+        transform: Callable[[Any], Any] | None = None,
+    ) -> None:
+        self._runtime = runtime
+        self._wan_number = wan_number
+        self._field = field
+        self._transform = transform
+        self._restored_value: Any = None
+        self._attr_unique_id = f"{entry_id}_{description.key}"
+        self._attr_device_info = device_info
+        self.entity_description = description
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last := await self.async_get_last_sensor_data()) is not None:
+            self._restored_value = last.native_value
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._runtime.speedtest_result_signal,
+                self._handle_result,
+            )
+        )
+
+    @callback
+    def _handle_result(self) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> Any:
+        result = self._runtime.speedtest_results.get(self._wan_number)
+        if result is None:
+            return self._restored_value
+        value = result.get(self._field)
+        return self._transform(value) if self._transform else value


### PR DESCRIPTION
## Summary
This PR enhances the UniFi WAN integration with per-WAN speedtest result tracking and improves the active WAN detection logic. The controller only stores the latest global speedtest result, so the integration now attributes each completed run to a specific WAN interface and maintains per-WAN history across restarts.

## Key Changes

- **Per-WAN Speedtest Sensors**: Added new `UniFiWanSpeedtestSensor` entities that track download, upload, ping, and last run timestamp for each WAN interface independently. These sensors use `RestoreSensor` to persist values across Home Assistant restarts.

- **Centralized WAN Resolution**: Extracted WAN detection logic into a new `resolve_active_wan()` function that serves as the single source of truth for both Active WAN ID and Active WAN Name sensors. This ensures the two sensors can never point at different interfaces.

- **Improved WAN Matching**: Enhanced WAN detection with a clear priority order:
  1. Match uplink IP against each WAN section's IP
  2. Match uplink port name against each WAN section's ifname
  3. Fall back to the only WAN that is up
  
  This handles load-balanced dual-WAN setups where the controller's uplink object can mix fields from both interfaces.

- **Speedtest Result Attribution**: Implemented `_process_speedtest_result()` callback that attributes completed speedtests to WAN interfaces using:
  1. Controller-reported speedtest interface (if available)
  2. WAN that was explicitly requested for the test
  3. Resolved active WAN as fallback

- **Auto-Speedtest Cycling**: Modified automatic speedtest scheduling to cycle through available WAN interfaces when multiple WANs have link, allowing each WAN to accumulate its own results over time.

- **Debug Attributes**: Added `_active_wan_attributes()` function that provides debugging information including the resolved WAN number, match reason, and per-WAN IP/interface mappings.

## Implementation Details

- New `UniFiWanSpeedtestSensor` class extends `RestoreSensor` to maintain per-WAN state across restarts
- Speedtest results are stored in `speedtest_results` dict keyed by WAN number
- A dispatcher signal (`SIGNAL_SPEEDTEST_RESULT`) notifies sensors when new results are available
- The `_interface_to_wan_number()` helper maps controller-reported interface names to WAN numbers, handling both logical names ("wan", "wan2") and physical port names
- Active WAN Name sensor now derives data from the same WAN section as Active WAN ID to prevent inconsistencies

https://claude.ai/code/session_01Bj1LZDYwkWuJMAJYPoR5r3