### PR TITLE
Attribute speedtests on evidence and label WANs by chassis port

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It does not support:
 
 **Speedtest**
 
-Speedtest values are taken from the gateway’s `uplink` section after a speedtest completes.
+Speedtest values are taken from the gateway’s `speedtest-status` block after a speedtest completes, falling back to the equivalent fields on the `uplink` section for firmware that does not report it.
 
 - **UniFi Speedtest Download**  
   - Gateway speedtest download result in **Mbit/s**  
@@ -64,22 +64,32 @@ Speedtest values are taken from the gateway’s `uplink` section after a speedte
 
 **Per-WAN speedtest**
 
-The controller only stores the *latest* speedtest result, overwriting it on every run regardless of interface. The integration therefore attributes each completed run to a WAN interface — using the controller-reported speedtest interface where available, otherwise the interface the test was requested on, otherwise the active WAN — and keeps the last result per WAN. Values survive Home Assistant restarts and update only when a speedtest actually runs on that WAN.
-
 - **UniFi WAN\* Speedtest Download** (**Mbit/s**)  
 - **UniFi WAN\* Speedtest Upload** (**Mbit/s**)  
 - **UniFi WAN\* Speedtest Ping** (**ms**)  
 - **UniFi WAN\* Speedtest Last Run** (timestamp)
 
+The controller only stores the *latest* speedtest result, overwriting it on every run regardless of interface, so the integration works out which WAN each completed run belongs to and keeps the last result per WAN. Values survive Home Assistant restarts and only change when a speedtest actually runs on that WAN.
+
+Attribution is made on evidence, never on which WAN was asked for:
+
+1. `speedtest-status.source_interface`, the controller's own record of the interface the test ran on.
+2. Failing that, the WAN that is currently the active uplink.
+
+**Many gateways ignore the requested interface and always test the active uplink.** On those, asking for a speedtest on a non-active WAN updates the *active* WAN's sensors instead, and the other WAN keeps its previous result rather than being given a figure that belongs to a different line. When this is detected it is logged as a warning and the automatic speedtest stops cycling interfaces. Each sensor's `attributed_by` attribute records which of the two rules above was used.
+
+Practically, this means a WAN accumulates its own speedtest results while it is the active uplink — for a failover setup, that is whenever it is carrying traffic.
+
 **WAN identification**
 
 - **UniFi Active WAN ID**  
   - Logical ID of the active WAN (e.g. `WAN1`), or `Unknown`  
-  - Derived by matching the uplink IP against each WAN section, then the uplink port name against each WAN section's interface name, then falling back to the only WAN that is up  
-  - Attributes include the resolved WAN, the match reason and the per-WAN IPs/interface names for debugging
+  - Derived by matching the uplink IP against each WAN section, then the uplink interface name against each WAN section's, then falling back to the only WAN that is up  
+  - Attributes include the resolved WAN, the match reason and the per-WAN IPs, interface names and ports for debugging
 - **UniFi Active WAN Name**  
-  - Human-friendly description of the currently active WAN  
-  - Always derived from the same WAN section as **UniFi Active WAN ID**, so the two sensors can never point at different interfaces (in load-balanced dual-WAN setups the controller's uplink object can mix fields from both interfaces)
+  - Human-friendly description of the currently active WAN, e.g. `Virgin Fibre (Port 9)` or `WAN1 (Port 9)` when the controller has no description of its own  
+  - Always derived from the same WAN section as **UniFi Active WAN ID**, so the two sensors can never point at different interfaces  
+  - The WAN is qualified by its **chassis port** rather than its raw kernel interface name. UniFi numbers interfaces from zero and ports from one, so `eth8` is the port labelled **9** on the case — reporting the interface name directly reads like the neighbouring port. The port is only ever taken from the controller's own `physical_ports`/`port_table` data; where that is unavailable the interface name is shown instead, and it is never converted by arithmetic.
 
 ---
 
@@ -159,7 +169,8 @@ All options are available via the integration’s **Options** UI and can be chan
   - Enable/disable automatic speedtests entirely.
 - **Auto speedtest interval (minutes)** (default **60**)  
   - How often to trigger an automatic speedtest when enabled.  
-  - With more than one WAN interface, each run cycles to the next WAN that currently has link, so every WAN accumulates its own per-WAN speedtest results over time. With a single WAN the plain speedtest command is used.
+  - With more than one WAN interface, each run cycles to the next WAN that currently has link, so every WAN accumulates its own per-WAN speedtest results over time. With a single WAN the plain speedtest command is used.  
+  - The rotation stops automatically if the gateway is seen to ignore the requested interface, since every run would then measure the active uplink anyway.
 
 ---
 

--- a/custom_components/unifi_wan/__init__.py
+++ b/custom_components/unifi_wan/__init__.py
@@ -68,6 +68,7 @@ class UniFiWanData:
     wan: dict[int, dict[str, Any]]
     wan_alive: dict[int, bool]
     wan_status: dict[int, str]
+    speedtest: dict[str, Any]
 
 
 @dataclass
@@ -165,9 +166,9 @@ class UnifiWanClient:
 
 
 def _log_raw_payload(gateway: dict[str, Any] | None, devices: list[dict]) -> None:
-    """Emit a debug log that surfaces the gateway fields relevant to the
-    IPv6 / speedtest_interface sensors so users can see what the controller
-    is actually returning. Enable with:
+    """Emit a debug log that surfaces the gateway fields behind the IPv6,
+    WAN identification and speedtest sensors so users can see what the
+    controller is actually returning. Enable with:
         logger:
           default: warning
           logs:
@@ -181,15 +182,29 @@ def _log_raw_payload(gateway: dict[str, Any] | None, devices: list[dict]) -> Non
     uplink = gateway.get("uplink") or {}
     wan_keys = [k for k in gateway.keys() if k == "wan" or (k.startswith("wan") and k[3:].isdigit())]
     wan_dump = {k: gateway.get(k) for k in wan_keys}
+    port_table = gateway.get("port_table")
+    ports = (
+        [
+            {k: p.get(k) for k in ("port_idx", "name", "ifname")}
+            for p in port_table
+            if isinstance(p, dict)
+        ]
+        if isinstance(port_table, list)
+        else None
+    )
     _LOGGER.debug(
         "UniFi raw gateway debug: uplink_keys=%s uplink.ip=%s uplink.ip6=%s "
-        "uplink.speedtest_interface=%s wan_blocks=%s last_wan_interfaces=%s",
+        "uplink.name=%s uplink.physical_ports=%s speedtest-status=%s "
+        "wan_blocks=%s last_wan_interfaces=%s port_table=%s",
         sorted(uplink.keys()),
         uplink.get("ip"),
         uplink.get("ip6"),
-        uplink.get("speedtest_interface"),
+        uplink.get("name"),
+        uplink.get("physical_ports"),
+        gateway.get("speedtest-status"),
         wan_dump,
         gateway.get("last_wan_interfaces"),
+        ports,
     )
 
 
@@ -231,6 +246,48 @@ def _get_ip6_from(data: dict[str, Any]) -> str | None:
                     if isinstance(addr, str) and _is_routable_ipv6(addr):
                         return addr
     return None
+
+
+def _normalise_interface(iface: Any) -> str | None:
+    """Clean a controller-reported interface name.
+
+    The speedtest block prefixes the interface with "if!" (e.g. "if!eth6")
+    and reports an empty string when it has nothing to say.
+    """
+    if not isinstance(iface, str):
+        return None
+    s = iface.strip()
+    if s.startswith("if!"):
+        s = s[3:]
+    return s or None
+
+
+def _extract_speedtest(
+    gateway: dict[str, Any] | None, uplink: dict[str, Any]
+) -> dict[str, Any]:
+    """Normalise the gateway's speedtest result into a single dict.
+
+    The authoritative source is the gateway's ``speedtest-status`` block,
+    which is the only place the controller records *which* interface the
+    test actually ran on (``source_interface``). The ``uplink`` fields carry
+    the same numbers under different names and are used as a fallback for
+    firmware that omits the block.
+    """
+    raw = gateway.get("speedtest-status") if gateway else None
+    status = raw if isinstance(raw, dict) else {}
+
+    def pick(primary: Any, fallback: Any) -> Any:
+        return primary if primary is not None else fallback
+
+    return {
+        "down": pick(status.get("xput_download"), uplink.get("xput_down")),
+        "up": pick(status.get("xput_upload"), uplink.get("xput_up")),
+        "ping": pick(status.get("latency"), uplink.get("speedtest_ping")),
+        "lastrun": pick(status.get("rundate"), uplink.get("speedtest_lastrun")),
+        "status": pick(status.get("status_summary"), uplink.get("speedtest_status")),
+        # None when the controller does not say; never guessed.
+        "source_interface": _normalise_interface(status.get("source_interface")),
+    }
 
 
 def _extract_wan_data(payload: dict[str, Any] | None) -> UniFiWanData:
@@ -328,6 +385,7 @@ def _extract_wan_data(payload: dict[str, Any] | None) -> UniFiWanData:
         wan=wan,
         wan_alive=wan_alive,
         wan_status=wan_status_map,
+        speedtest=_extract_speedtest(gateway, uplink),
     )
 
 
@@ -358,24 +416,27 @@ def resolve_active_wan(d: UniFiWanData) -> tuple[int | None, str]:
     return None, "no_match"
 
 
-def _interface_to_wan_number(iface: Any, wan: dict[int, dict[str, Any]]) -> int | None:
-    """Map a controller-reported speedtest interface to a WAN number.
+def interface_to_wan_number(iface: Any, wan: dict[int, dict[str, Any]]) -> int | None:
+    """Map a controller-reported interface to a WAN number.
 
-    Handles the "wan"/"wan2" naming used by the speedtest command as well
-    as physical port names (e.g. "eth8") that some firmware reports.
+    Matches against each WAN section's own interface fields, so PPPoE
+    uplinks ("ppp0") resolve as readily as plain ethernet ones. The
+    "wan"/"wan2" spellings used by the speedtest command are handled too,
+    but only after the section match: a literal interface name is stronger
+    evidence than a naming convention.
     """
-    if not isinstance(iface, str):
-        return None
-    s = iface.strip().lower()
+    s = _normalise_interface(iface)
     if not s:
         return None
+    s = s.lower()
+    for wan_number, wan_data in wan.items():
+        for key in ("ifname", "name"):
+            if s == str(wan_data.get(key) or "").strip().lower():
+                return wan_number
     if s == "wan":
         return 1
     if s.startswith("wan") and s[3:].isdigit():
         return int(s[3:])
-    for wan_number, wan_data in wan.items():
-        if s == str(wan_data.get("ifname") or "").strip().lower():
-            return wan_number
     return None
 
 
@@ -503,15 +564,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unsub_auto: CALLBACK_TYPE | None = None
 
     # Per-WAN speedtest results latched by _process_speedtest_result. The
-    # controller only stores the latest result (on the uplink object), so the
-    # integration attributes each completed run to a WAN and keeps it here.
+    # controller only stores the latest result, so the integration attributes
+    # each completed run to a WAN and keeps it here.
     speedtest_results: dict[int, dict[str, Any]] = {}
     # WAN number requested for the speedtest currently in flight, if any.
+    # Used only to report on the controller's behaviour - never to attribute
+    # a result. See _process_speedtest_result.
     pending_speedtest_wan: int | None = None
+    # None until a targeted run tells us whether this controller honours the
+    # requested interface; False disables the auto-speedtest WAN rotation.
+    per_wan_speedtest_supported: bool | None = None
     # Seed with the result already on the controller so a stale run isn't
     # re-attributed after every restart; per-WAN sensors restore their own
     # previous state instead.
-    last_attributed_run = device_coordinator.data.uplink.get("speedtest_lastrun")
+    last_attributed_run = device_coordinator.data.speedtest.get("lastrun")
 
     def _dispatch_running():
         async_dispatcher_send(hass, entry_signal)
@@ -520,39 +586,70 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     def _process_speedtest_result() -> None:
         """Attribute a freshly completed speedtest to a WAN interface.
 
-        Runs on every device coordinator refresh. Attribution order: the
-        controller-reported speedtest interface, then the WAN the in-flight
-        request targeted, then the resolved active WAN.
+        Runs on every device coordinator refresh. A result is only ever
+        attributed on evidence: the interface the controller says the test
+        ran on, or failing that the WAN that is currently the active uplink.
+        The requested interface is deliberately not used as a fallback -
+        many firmware versions ignore it and always test the active uplink,
+        so trusting the request labels one WAN's throughput as another's.
         """
-        nonlocal last_attributed_run
+        nonlocal last_attributed_run, per_wan_speedtest_supported
         data: UniFiWanData | None = device_coordinator.data
-        if not data or not data.uplink:
+        if not data:
             return
-        lastrun = data.uplink.get("speedtest_lastrun")
+        result = data.speedtest
+        lastrun = result.get("lastrun")
         if not lastrun or lastrun == last_attributed_run:
             return
-        last_attributed_run = lastrun
-        down = data.uplink.get("xput_down")
-        up = data.uplink.get("xput_up")
-        if down is None and up is None:
+        if result.get("down") is None and result.get("up") is None:
             return
-        wan_number = _interface_to_wan_number(
-            data.uplink.get("speedtest_interface"), data.wan
-        )
-        if wan_number is None:
-            wan_number = pending_speedtest_wan
+        last_attributed_run = lastrun
+
+        requested = pending_speedtest_wan
+        wan_number = interface_to_wan_number(result.get("source_interface"), data.wan)
+        source = "source_interface"
         if wan_number is None:
             wan_number, _ = resolve_active_wan(data)
+            source = "active_wan"
         if wan_number is None:
-            _LOGGER.debug("Speedtest result could not be attributed to a WAN")
+            _LOGGER.debug(
+                "Speedtest result could not be attributed to a WAN "
+                "(source_interface=%r)",
+                result.get("source_interface"),
+            )
             return
+
+        if requested is not None and requested != wan_number:
+            if per_wan_speedtest_supported is not False:
+                per_wan_speedtest_supported = False
+                _LOGGER.warning(
+                    "Speedtest was requested on WAN%s but the controller ran it "
+                    "on WAN%s (matched by %s). This gateway appears to always "
+                    "test the active uplink, so per-WAN speedtest requests are "
+                    "not supported; the result has been recorded against WAN%s "
+                    "and the automatic speedtest will stop cycling interfaces.",
+                    requested,
+                    wan_number,
+                    source,
+                    wan_number,
+                )
+        elif requested is not None and source == "source_interface":
+            per_wan_speedtest_supported = True
+
         speedtest_results[wan_number] = {
-            "down": down,
-            "up": up,
-            "ping": data.uplink.get("speedtest_ping"),
+            "down": result.get("down"),
+            "up": result.get("up"),
+            "ping": result.get("ping"),
             "lastrun": lastrun,
+            "source": source,
+            "requested_wan": requested,
         }
-        _LOGGER.debug("Attributed speedtest result to WAN%s", wan_number)
+        _LOGGER.debug(
+            "Attributed speedtest result to WAN%s (matched by %s, requested %s)",
+            wan_number,
+            source,
+            requested,
+        )
         async_dispatcher_send(hass, result_signal)
 
     entry.async_on_unload(
@@ -590,7 +687,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _LOGGER.warning("Cannot run speedtest: No gateway found.")
                 return
 
-            last_run_before = gw_data.uplink.get("speedtest_lastrun")
+            last_run_before = gw_data.speedtest.get("lastrun")
             await client.run_speedtest(mac_local, wan_number)
 
             # Poll until the controller reports a new result or we time out.
@@ -599,7 +696,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 await asyncio.sleep(SPEEDTEST_POLL_SECONDS)
                 await device_coordinator.async_request_refresh()
                 gw_data = device_coordinator.data
-                last_run = gw_data.uplink.get("speedtest_lastrun") if gw_data else None
+                last_run = gw_data.speedtest.get("lastrun") if gw_data else None
                 if last_run and last_run != last_run_before:
                     break
             else:
@@ -620,16 +717,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def _auto_speedtest_callback(_now) -> None:
         """Run the scheduled speedtest, cycling through the WAN interfaces
         that currently have link so each WAN accumulates its own results.
-        With a single WAN the plain speedtest command is kept for maximum
-        firmware compatibility.
+
+        The rotation stops as soon as the controller is seen to ignore a
+        requested interface (see _process_speedtest_result): on those
+        gateways every run tests the active uplink anyway, so cycling would
+        only spend extra tests to measure the same WAN repeatedly.
         """
         nonlocal auto_wan_index
+        if per_wan_speedtest_supported is False:
+            await _run_speedtest_now()
+            return
         data: UniFiWanData | None = device_coordinator.data
         candidates = [
             n for n in wan_numbers if (data.wan.get(n) or {}).get("up")
         ] if data else []
-        if not candidates:
-            candidates = list(wan_numbers)
         if len(candidates) > 1:
             wan_number = candidates[auto_wan_index % len(candidates)]
             auto_wan_index += 1

--- a/custom_components/unifi_wan/sensor.py
+++ b/custom_components/unifi_wan/sensor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from dataclasses import dataclass
 from typing import Any, Callable, Final
@@ -15,6 +16,7 @@ from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import ExtraStoredData
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -22,10 +24,31 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.config_entries import ConfigEntry
 
 from .const import DOMAIN
-from . import UniFiWanData, UniFiWanRuntimeData, resolve_active_wan
+from . import (
+    UniFiWanData,
+    UniFiWanRuntimeData,
+    interface_to_wan_number,
+    resolve_active_wan,
+)
 
 
 DATA_RATE_UNIT_MEGABITS_PER_SECOND: Final = "Mbit/s"
+
+# Bumped whenever per-WAN speedtest results stop being comparable with those
+# stored by earlier releases; values stamped with an older version are not
+# restored. See UniFiWanSpeedtestSensor._restored_value_is_trusted.
+ATTRIBUTION_VERSION: Final = 2
+
+
+@dataclass
+class _WanSpeedtestExtraData(ExtraStoredData):
+    """Restore-state payload recording how a stored result was attributed."""
+
+    version: int
+    source: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"version": self.version, "source": self.source}
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -60,55 +83,133 @@ def _wan_id(d: UniFiWanData) -> str:
     return f"WAN{wan_number}" if wan_number is not None else "Unknown"
 
 
+_INTERFACE_NAME_RE: Final = re.compile(r"(eth|ppp|pppoe|bond|br|vlan|wan)\d*(\.\d+)?")
+
+
+def _looks_like_interface(value: str) -> bool:
+    """True for controller placeholders like "eth8", "ppp0", "WAN" or "wan2"
+    that name a link rather than describe it.
+    """
+    return bool(_INTERFACE_NAME_RE.fullmatch(value.strip().lower()))
+
+
+def _port_label(d: UniFiWanData, wan_data: dict[str, Any]) -> str | None:
+    """Chassis port label for a WAN, e.g. "Port 9".
+
+    Only ever read from the controller's own physical_ports/port_table data,
+    never computed from the interface name: UniFi numbers kernel interfaces
+    from zero while the chassis ports are labelled from one, so eth8 is the
+    port silk-screened 9. Deriving one from the other would turn a wrong
+    guess into a confident-looking answer, so an unrecognised layout yields
+    no port label at all.
+    """
+    ports = wan_data.get("physical_ports")
+    if isinstance(ports, list):
+        labels = [str(p).strip() for p in ports if str(p).strip()]
+        if labels:
+            return f"Port {'/'.join(labels)}"
+
+    ifname = str(wan_data.get("ifname") or "").strip().lower()
+    port_table = (d.gateway or {}).get("port_table")
+    if ifname and isinstance(port_table, list):
+        for port in port_table:
+            if not isinstance(port, dict):
+                continue
+            if str(port.get("ifname") or "").strip().lower() != ifname:
+                continue
+            name = str(port.get("name") or "").strip()
+            if name:
+                return name
+            idx = port.get("port_idx")
+            if idx is not None:
+                return f"Port {idx}"
+    return None
+
+
+def _active_port_label(d: UniFiWanData, section: dict[str, Any], reason: str) -> str | None:
+    """Chassis port for the active WAN, allowing the uplink block to supply
+    it when the WAN section itself carries no port data.
+
+    Only the "uplink_*" match reasons prove the uplink block describes this
+    WAN; after an "only_wan_up" match it has told us nothing about which
+    interface it refers to, so its ports are not borrowed.
+    """
+    label = _port_label(d, section)
+    if label is None and reason.startswith("uplink_"):
+        label = _port_label(d, d.uplink)
+    return label
+
+
+def _friendly_wan_name(section: dict[str, Any]) -> str:
+    """The user-facing description of a WAN, if the controller has one."""
+    for key in ("comment", "name"):
+        value = str(section.get(key) or "").strip()
+        if value and not _looks_like_interface(value):
+            return value
+    return ""
+
+
 def _wan_name(d: UniFiWanData) -> str:
     """Get Active WAN Name, derived from the same WAN section as the Active
-    WAN ID so the two sensors can never point at different interfaces. The
-    controller's uplink comment/name fields are only trusted when they agree
-    with the resolved WAN section (or when no section resolved at all): in
-    load-balanced dual-WAN setups the uplink object can mix fields from both
-    interfaces, e.g. WAN1's IP alongside WAN2's port name.
+    WAN ID so the two sensors can never point at different interfaces.
+
+    The state leads with the WAN's description, or its WAN number when the
+    controller only offers placeholders, and qualifies it with the chassis
+    port rather than the raw interface name - "eth8" reads like port 8 but
+    is in fact port 9, which is exactly the confusion this avoids.
     """
-    wan_number, _ = resolve_active_wan(d)
+    wan_number, reason = resolve_active_wan(d)
     if wan_number is None:
-        c = (d.uplink.get("comment") or "").strip()
-        n = (d.uplink.get("name") or "").strip()
-    else:
-        wan_data = d.wan.get(wan_number) or {}
-        ifname = (wan_data.get("ifname") or "").strip()
-        c = (wan_data.get("comment") or "").strip()
-        n = (wan_data.get("name") or "").strip() or ifname
-        if not c:
-            u_name = (d.uplink.get("name") or "").strip()
-            if u_name and u_name.lower() == ifname.lower():
-                c = (d.uplink.get("comment") or "").strip()
-    if c and n and c.lower() != n.lower():
-        return f"{c} ({n})"
-    return c or n or "Unknown"
+        friendly = _friendly_wan_name(d.uplink)
+        return friendly or "Unknown"
+
+    section = d.wan.get(wan_number) or {}
+    friendly = _friendly_wan_name(section)
+    if not friendly and reason.startswith("uplink_"):
+        friendly = _friendly_wan_name(d.uplink)
+
+    label = friendly or f"WAN{wan_number}"
+    detail = _active_port_label(d, section, reason) or str(
+        section.get("ifname") or ""
+    ).strip()
+    if detail and detail.lower() != label.lower():
+        return f"{label} ({detail})"
+    return label
 
 
 def _active_wan_attributes(d: UniFiWanData) -> dict[str, Any]:
     """Debug attributes showing how the active WAN was resolved."""
     wan_number, reason = resolve_active_wan(d)
+    section = d.wan.get(wan_number) or {} if wan_number is not None else {}
     return {
         "active_wan": wan_number,
         "match_reason": reason,
+        "active_wan_ifname": section.get("ifname"),
+        "active_wan_port": _active_port_label(d, section, reason) if section else None,
         "uplink_ip": d.uplink.get("ip"),
         "uplink_name": d.uplink.get("name"),
         "uplink_comment": d.uplink.get("comment"),
         "wan_ips": {f"WAN{n}": (w or {}).get("ip") for n, w in d.wan.items()},
         "wan_ifnames": {f"WAN{n}": (w or {}).get("ifname") for n, w in d.wan.items()},
+        "wan_ports": {
+            f"WAN{n}": _port_label(d, w or {}) for n, w in d.wan.items()
+        },
     }
 
 
 def _speedtest_interface(d: UniFiWanData) -> str:
-    """Return the controller-reported speedtest interface, or fall back
-    to the active WAN ID. Newer/older controller versions don't always
-    populate uplink.speedtest_interface, but the speedtest always runs
-    against the active uplink so the active WAN ID is a safe fallback.
+    """Return the WAN the last speedtest ran on.
+
+    The controller records this in speedtest-status.source_interface, which
+    is reported as a raw interface name ("eth6"); it is resolved to the
+    matching WAN number so the state lines up with the other WAN sensors.
+    When the controller leaves it empty the active WAN is the best available
+    answer, since the test then ran against the active uplink.
     """
-    iface = d.uplink.get("speedtest_interface")
+    iface = d.speedtest.get("source_interface")
     if iface:
-        return iface
+        wan_number = interface_to_wan_number(iface, d.wan)
+        return f"WAN{wan_number}" if wan_number is not None else iface
     active = _wan_id(d)
     return active if active != "Unknown" else "unknown"
 
@@ -179,7 +280,7 @@ SENSORS: Final[tuple[UniFiSensorDescription, ...]] = (
         device_class=SensorDeviceClass.DATA_RATE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=DATA_RATE_UNIT_MEGABITS_PER_SECOND,
-        value_fn=lambda d: d.uplink.get("xput_down"),
+        value_fn=lambda d: d.speedtest.get("down"),
     ),
     UniFiSensorDescription(
         key="speedtest_up",
@@ -188,7 +289,7 @@ SENSORS: Final[tuple[UniFiSensorDescription, ...]] = (
         device_class=SensorDeviceClass.DATA_RATE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=DATA_RATE_UNIT_MEGABITS_PER_SECOND,
-        value_fn=lambda d: d.uplink.get("xput_up"),
+        value_fn=lambda d: d.speedtest.get("up"),
     ),
     UniFiSensorDescription(
         key="speedtest_ping",
@@ -197,14 +298,14 @@ SENSORS: Final[tuple[UniFiSensorDescription, ...]] = (
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTime.MILLISECONDS,
-        value_fn=lambda d: d.uplink.get("speedtest_ping"),
+        value_fn=lambda d: d.speedtest.get("ping"),
     ),
     UniFiSensorDescription(
         key="speedtest_last_run",
         name="UniFi Speedtest Last Run",
         icon="mdi:clock-outline",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda d: _ts_date(d.uplink.get("speedtest_lastrun")),
+        value_fn=lambda d: _ts_date(d.speedtest.get("lastrun")),
     ),
     UniFiSensorDescription(
         key="speedtest_interface",
@@ -212,12 +313,12 @@ SENSORS: Final[tuple[UniFiSensorDescription, ...]] = (
         icon="mdi:wan",
         value_fn=_speedtest_interface,
         attributes_fn=lambda d: {
-            "raw_speedtest_interface": d.uplink.get("speedtest_interface"),
-            "derived_from_active_wan": not bool(d.uplink.get("speedtest_interface")),
-            "speedtest_lastrun": d.uplink.get("speedtest_lastrun"),
-            "speedtest_status": d.uplink.get("speedtest_status"),
-            "xput_down": d.uplink.get("xput_down"),
-            "xput_up": d.uplink.get("xput_up"),
+            "raw_speedtest_interface": d.speedtest.get("source_interface"),
+            "derived_from_active_wan": not bool(d.speedtest.get("source_interface")),
+            "speedtest_lastrun": d.speedtest.get("lastrun"),
+            "speedtest_status": d.speedtest.get("status"),
+            "xput_down": d.speedtest.get("down"),
+            "xput_up": d.speedtest.get("up"),
         },
     ),
     UniFiSensorDescription(
@@ -382,10 +483,10 @@ class UniFiWanSpeedtestSensor(RestoreSensor):
     """Per-WAN speedtest result, latched by the integration whenever a
     completed speedtest is attributed to this WAN interface.
 
-    The controller only stores the latest result globally (on the gateway's
-    uplink object), overwriting it on every run regardless of interface, so
-    these sensors keep the last value seen for their WAN and restore it
-    across restarts instead of re-reading it from the API.
+    The controller only stores the latest result globally, overwriting it on
+    every run regardless of interface, so these sensors keep the last value
+    seen for their WAN and restore it across restarts instead of re-reading
+    it from the API.
     """
 
     _attr_should_poll = False
@@ -409,10 +510,22 @@ class UniFiWanSpeedtestSensor(RestoreSensor):
         self._attr_device_info = device_info
         self.entity_description = description
 
+    @property
+    def extra_restore_state_data(self) -> _WanSpeedtestExtraData:
+        """Stamp stored values with the attribution scheme that produced
+        them, so a later release can tell which ones it may trust.
+        """
+        result = self._runtime.speedtest_results.get(self._wan_number)
+        return _WanSpeedtestExtraData(
+            version=ATTRIBUTION_VERSION,
+            source=result.get("source") if result else None,
+        )
+
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
-        if (last := await self.async_get_last_sensor_data()) is not None:
-            self._restored_value = last.native_value
+        if await self._restored_value_is_trusted():
+            if (last := await self.async_get_last_sensor_data()) is not None:
+                self._restored_value = last.native_value
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
@@ -420,6 +533,25 @@ class UniFiWanSpeedtestSensor(RestoreSensor):
                 self._handle_result,
             )
         )
+
+    async def _restored_value_is_trusted(self) -> bool:
+        """Whether a stored value may be shown again after a restart.
+
+        Values written before ATTRIBUTION_VERSION 2 are discarded: that
+        release attributed a result to whichever WAN the speedtest was
+        requested on, which on gateways that only ever test the active
+        uplink recorded one line's throughput against another. Those
+        figures would otherwise survive indefinitely on a WAN that is
+        rarely active, so they are dropped rather than trusted.
+        """
+        extra = await self.async_get_last_extra_data()
+        if extra is None:
+            return False
+        stored = extra.as_dict() or {}
+        try:
+            return int(stored.get("version", 0)) >= ATTRIBUTION_VERSION
+        except (TypeError, ValueError):
+            return False
 
     @callback
     def _handle_result(self) -> None:
@@ -432,3 +564,17 @@ class UniFiWanSpeedtestSensor(RestoreSensor):
             return self._restored_value
         value = result.get(self._field)
         return self._transform(value) if self._transform else value
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        result = self._runtime.speedtest_results.get(self._wan_number)
+        if result is None:
+            return {"attributed_by": None, "restored": True}
+        return {
+            # How this WAN was identified as the one the test ran on:
+            # "source_interface" is the controller's own record, "active_wan"
+            # means it was inferred from the active uplink instead.
+            "attributed_by": result.get("source"),
+            "requested_wan": result.get("requested_wan"),
+            "restored": False,
+        }


### PR DESCRIPTION
Fixes #38 and #39, both caused by building on assumed controller fields rather than the ones the API actually returns (see the payload dumps in #9).

Speedtest attribution (#38):
- Read results from the gateway's speedtest-status block, whose source_interface is the only record of which interface a test ran on; uplink.speedtest_interface, previously relied on, does not exist. The uplink fields remain a fallback for firmware without the block
- Never attribute a result to the requested WAN. Many gateways ignore the requested interface and always test the active uplink, so trusting the request recorded one line's throughput against another - the reported symptom of a 100 Mbps WAN showing 1000 Mbps. Attribution now uses source_interface, else the active WAN, and nothing else
- Warn and stop the auto-speedtest WAN rotation once the controller is seen to ignore a requested interface, instead of re-testing the same WAN hourly
- Version stored per-WAN values so results written by the previous release are discarded rather than restored indefinitely on a rarely-active WAN

WAN naming (#39):
- Qualify the Active WAN Name with the chassis port from the controller's physical_ports/port_table rather than the raw interface name. UniFi numbers interfaces from zero and ports from one, so eth8 is the port labelled 9 and reading it as a port number is off by one. The port is never computed from the interface name, so an unrecognised layout shows the interface instead of a confident wrong answer
- Lead with the WAN's description, or its WAN number when the controller only supplies placeholders like "WAN" or "ppp0"

Also resolve the speedtest interface sensor to a WAN number, extend the debug payload log to the fields these sensors actually read, and expose the port and attribution source as attributes.


Claude-Session: https://claude.ai/code/session_01Bj1LZDYwkWuJMAJYPoR5r3