### PR TITLE
Add diagnostics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,20 @@ All sensors, binary sensors, buttons and switches are attached to this device so
 
 ---
 
+## Diagnostics
+
+**Settings → Devices & Services → UniFi WAN → ⋮ → Download diagnostics**
+
+Produces a JSON file containing what the controller sent and what the integration made of it — the fastest way to get a bug report answered, and it needs no logger configuration:
+
+- The gateway's payload verbatim: the WAN sections, `uplink`, `speedtest-status`, `port_table` and `last_wan_interfaces`
+- The per-WAN speedtest API's raw response, where the controller offers one
+- The integration's own conclusions: the resolved active WAN and how it was matched, the parsed per-WAN results, and the values the sensors are currently showing
+
+Credentials, MAC addresses, public IP addresses, serial numbers, account identifiers, DNS servers and the speedtest server's location are redacted. Because addresses are hidden, whether two of them matched is reported in the `derived` section rather than left to be inferred. **Please attach this file when opening an issue.**
+
+---
+
 ## Install
 
 ### HACS

--- a/custom_components/unifi_wan/__init__.py
+++ b/custom_components/unifi_wan/__init__.py
@@ -72,6 +72,9 @@ class UniFiWanData:
     # Per-WAN speedtest results straight from the controller, keyed by WAN
     # number. Empty when the controller has no per-WAN speedtest API.
     per_wan_speedtest: dict[int, dict[str, Any]] = field(default_factory=dict)
+    # The per-WAN speedtest API's last response, kept verbatim so diagnostics
+    # can show what the controller actually returned. None when unavailable.
+    speedtest_history_raw: dict[str, Any] | None = None
 
 
 @dataclass
@@ -722,6 +725,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # which beats inferring which WAN a global result belonged to.
         history = await client.get_speedtest_history()
         if history is not None:
+            data.speedtest_history_raw = history
             data.per_wan_speedtest = parse_speedtest_history(history, data.wan)
         return data
 

--- a/custom_components/unifi_wan/diagnostics.py
+++ b/custom_components/unifi_wan/diagnostics.py
@@ -1,0 +1,155 @@
+"""Diagnostics support for UniFi WAN.
+
+Adds a "Download diagnostics" button to the integration page that returns
+what the controller actually sent, alongside what the integration made of
+it. Nearly every issue raised against this integration has come down to
+that comparison, and this needs no logger configuration to produce.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.loader import async_get_integration
+
+from .const import DOMAIN
+from . import UniFiWanData, UniFiWanRuntimeData, resolve_active_wan
+
+# Applied recursively by key, to the controller payload as well as to the
+# config entry. Structural fields the WAN logic turns on - ifname,
+# physical_ports, port_idx, up/enable flags, speedtest figures, timestamps,
+# wan_networkgroup, source_interface - are deliberately left intact.
+#
+# Addresses are redacted, which also hides whether two of them matched, so
+# the "derived" section reports the outcome of those comparisons instead.
+TO_REDACT: set[str] = {
+    # Credentials and where the console lives
+    "api_key",
+    "host",
+    "x_aes_gcm_keys",
+    "x_authkey",
+    "x_fingerprint",
+    "x_ssh_hostkey_fingerprint",
+    "x_vwirekey",
+    # Addressing
+    "ip",
+    "ip6",
+    "ipv6",
+    "ip6_address",
+    "ip6_addresses",
+    "ipv6_addresses",
+    "lan_ip",
+    "wan_ip",
+    "gateway",
+    "gateway_v6",
+    "dns",
+    "nameservers",
+    "nameservers_dynamic",
+    # Hardware and account identifiers
+    "mac",
+    "ap_mac",
+    "gw_mac",
+    "sw_mac",
+    "bssid",
+    "serial",
+    "serial_number",
+    "_id",
+    "anon_id",
+    "anonymous_id",
+    "device_id",
+    "hash_id",
+    "site_id",
+    "hostname",
+    # Speedtest server location, which locates the subscriber too
+    "provider_url",
+    "city",
+    "lat",
+    "lon",
+    "latitude",
+    "longitude",
+}
+
+
+def _device_summary(devices: list[dict], gateway: dict[str, Any] | None) -> list[dict]:
+    """Everything on the site other than the gateway, named but not dumped.
+
+    Only the gateway's own payload drives this integration, so the rest is
+    reduced to enough context to spot a misidentified gateway.
+    """
+    gateway_id = id(gateway) if gateway else None
+    summary = []
+    for device in devices:
+        if not isinstance(device, dict) or id(device) == gateway_id:
+            continue
+        summary.append(
+            {
+                "type": device.get("type"),
+                "model": device.get("model"),
+                "adopted": device.get("adopted"),
+                "has_uplink": "uplink" in device,
+            }
+        )
+    return summary
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    runtime: UniFiWanRuntimeData = hass.data[DOMAIN][entry.entry_id]
+    data: UniFiWanData | None = runtime.device_coordinator.data
+
+    try:
+        integration = await async_get_integration(hass, DOMAIN)
+        version = str(integration.version)
+    except Exception:  # pragma: no cover - version is a nicety, not a feature
+        version = None
+
+    diagnostics: dict[str, Any] = {
+        "integration": {
+            "version": version,
+            "gateway_model": runtime.dev_meta.get("model"),
+            "gateway_firmware": runtime.dev_meta.get("sw_version"),
+        },
+        "entry": {
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "options": async_redact_data(dict(entry.options), TO_REDACT),
+        },
+    }
+
+    if data is None:
+        diagnostics["error"] = "coordinator has no data"
+        return diagnostics
+
+    active_wan, match_reason = resolve_active_wan(data)
+    diagnostics["derived"] = {
+        # What the integration concluded, so a wrong conclusion can be told
+        # apart from wrong data.
+        "wan_numbers": runtime.wan_numbers,
+        "active_wan": active_wan,
+        "match_reason": match_reason,
+        "wan_alive": data.wan_alive,
+        "wan_status": data.wan_status,
+        "speedtest": data.speedtest,
+        "per_wan_speedtest": data.per_wan_speedtest,
+        # What the sensors are actually showing, which can lag the above.
+        "latched_speedtest_results": runtime.speedtest_results,
+        "per_wan_api_available": data.speedtest_history_raw is not None,
+        "targeted_speedtest_supported": runtime.client.targeted_speedtest_supported,
+        "auto_speedtest_enabled": runtime.auto_enabled,
+        "speedtest_running": runtime.get_speedtest_running(),
+    }
+    diagnostics["controller"] = {
+        # The gateway verbatim: WAN sections, uplink, speedtest-status,
+        # port_table and everything else it reports.
+        "gateway_device": async_redact_data(data.gateway or {}, TO_REDACT),
+        # The per-WAN speedtest API's raw response, the source of the
+        # per-WAN sensors.
+        "speedtest_history": async_redact_data(
+            data.speedtest_history_raw or {}, TO_REDACT
+        ),
+        "other_devices": _device_summary(data.devices, data.gateway),
+    }
+    return diagnostics


### PR DESCRIPTION
Adds a **Download diagnostics** button to the integration page.

Every issue raised here has come down to the same question — what is the controller actually returning — and answering it has meant talking a reporter through logger configuration. That has been failing lately: one reporter on #38 has repeatedly got nothing from debug logging, and recent Home Assistant versions no longer leave a `home-assistant.log` to fall back on. This makes the answer one click.

> **Based on `claude/unifi-wan-sensor-issues-82rsxx` (#41), not `main`** — it reports the per-WAN speedtest data that PR introduces. GitHub will retarget this to `main` automatically when #41 merges. Review it after that one.

## What the file contains

**The controller, verbatim**
- The gateway's payload: the `wan1`/`wan2` sections, `uplink`, `speedtest-status`, `port_table`, `last_wan_interfaces`
- The per-WAN speedtest API's raw response — `UniFiWanData` now retains it for this purpose
- Every other device on the site named but not dumped (type, model, adopted, whether it has an uplink), enough to spot a misidentified gateway without the bulk

**What the integration made of it**
- The resolved active WAN and the reason it matched
- The parsed per-WAN speedtest results
- The values the sensors are currently showing, which can lag the above
- Whether the per-WAN API is available, whether the controller accepts targeted speedtests, and the auto-speedtest state

Splitting those two apart is the point: it distinguishes a wrong conclusion from wrong data, which is the distinction every round of #38 and #39 has turned on.

## Redaction

Credentials, MAC addresses, public IP addresses, serial numbers, account identifiers (`_id`, `device_id`, `site_id`, `hash_id`), hostnames, DNS servers and the speedtest server's location are redacted through HA's `async_redact_data`.

Two deliberate choices:

- Redacting addresses also hides **whether two of them were equal** — which is exactly what the active-WAN matching turns on. The `derived` section therefore reports the outcome of that comparison (`active_wan`, `match_reason`) rather than leaving it to be inferred from redacted values.
- Fields the WAN logic depends on are left intact: `ifname`, `physical_ports`, `port_idx`, `up`/`enable` flags, speedtest figures, timestamps, `wan_networkgroup`, `source_interface`.

## Testing

Run against a realistic UDM Pro payload using a faithful copy of HA's `async_redact_data` rather than a passthrough, so redaction is genuinely exercised — including nested cases (`last_wan_interfaces.WAN.ip`, `port_table[].mac`, `speedtest-status.server.provider_url`). Two-sided: a sweep asserts no secret string survives anywhere in the output, and separate assertions confirm every debugging-relevant field does. Also covers the pre-first-refresh case, where the file still returns the redacted entry rather than raising.

Please attach this file when opening an issue — noted in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj1LZDYwkWuJMAJYPoR5r3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bj1LZDYwkWuJMAJYPoR5r3)_